### PR TITLE
Add installation instructions page

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
     <img class="hero-img" src="https://images.unsplash.com/photo-1585079546026-13d4f27cd8d4?auto=format&fit=crop&w=800&q=80" alt="Серверная" />
     <h1>GPT-Админ — умный помощник для серверов</h1>
     <p class="subtitle">ChatGPT, который не только советует, но и сам выполняет команды на ваших серверах.</p>
-    <a href="#install" class="cta">🚀 Установить за 1 минуту</a>
+    <a href="instructions.html" class="cta">🚀 Установить за 1 минуту</a>
     <pre><code>curl -s https://get.gpt-admin.sh | sh</code></pre>
   </section>
 
@@ -72,7 +72,7 @@
 
   <section class="cta-final fade-section" id="install">
     <h2>Попробуй прямо сейчас — установка занимает 1 минуту!</h2>
-    <a href="#" class="cta">🚀 Установить за 1 минуту</a>
+    <a href="instructions.html" class="cta">🚀 Установить за 1 минуту</a>
     <pre><code>curl -s https://get.gpt-admin.sh | sh</code></pre>
   </section>
 

--- a/instructions.html
+++ b/instructions.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Инструкция по установке GPT-Админ</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-pLX+q9E9np5xpoE2mR7BfrpsbR9f7DmqDveoxu48UUfGzfo0RKZ77N8BINU3CFAaj6MqFmoVoe2MtkNAaXo4w==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <section class="fade-section">
+    <h1>📖 Инструкция по установке GPT-Админ</h1>
+    <h2>1. Установка компонентов</h2>
+    <p>GPT-Админ состоит из двух частей:</p>
+    <ul>
+      <li><strong>hub_proxy</strong> — центральный сервер, собирает и отправляет запросы.</li>
+      <li><strong>rootd</strong> — клиент-агент, который выполняет команды на конкретной машине.</li>
+    </ul>
+    <p>Установите их так:</p>
+    <h3>На главный компьютер (с hub_proxy)</h3>
+    <pre><code>curl -s https://gptadmin.bezrabotnyi.com/install-hub.sh | bash</code></pre>
+    <h3>На остальные компьютеры (с rootd)</h3>
+    <pre><code>curl -s https://gptadmin.bezrabotnyi.com/install-rootd.sh | bash</code></pre>
+  </section>
+
+  <section class="fade-section">
+    <h2>2. Подключение к ChatGPT</h2>
+    <ol>
+      <li>Зайдите в ChatGPT.</li>
+      <li>Создайте <strong>новый плагин</strong>.</li>
+      <li>В настройках добавьте действие, укажите URL API, который выдал скрипт после установки hub_proxy.</li>
+    </ol>
+  </section>
+
+  <section class="fade-section">
+    <h2>3. OpenAPI описание</h2>
+    <p>GPT сам подтянет описание API из вашего hub_proxy. Оно доступно по адресу:</p>
+    <pre><code>https://gptadmin.bezrabotnyi.com/openapi.json</code></pre>
+    <p>Пример (сокращённый):</p>
+    <pre><code>{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "GPTAdmin Hub & Rootd API",
+    "version": "2.0.0",
+    "description": "Полный список proxied rootd-endpoint’ов через hub-proxy"
+  },
+  "servers": [
+    {
+      "url": "https://gptadmin.bezrabotnyi.com"
+    }
+  ]
+}</code></pre>
+  </section>
+
+  <section class="fade-section">
+    <h2>4. Промт для ChatGPT</h2>
+    <p>Используйте этот промт, чтобы GPT понимал, как работать:</p>
+    <pre><code>Ты — GPT-Админ. У тебя есть доступ к API, который управляет серверами.
+Не давай инструкции пользователю, а выполняй их сам через API.
+Перед изменением файлов всегда читай содержимое, потом вноси изменения, потом снова читай для проверки.
+Перед удалением или изменением сети всегда спрашивай подтверждение.
+</code></pre>
+  </section>
+
+  <section class="fade-section">
+    <h2>5. Готово 🎉</h2>
+    <p>Теперь можно писать в ChatGPT простыми словами:</p>
+    <ul>
+      <li>«Поставь Minecraft-сервер»</li>
+      <li>«Сделай VPN»</li>
+      <li>«Перезапусти nginx»</li>
+      <li>«Покажи использование памяти»</li>
+    </ul>
+    <p>GPT-Админ выполнит команды сам, через <code>rootd</code>.</p>
+  </section>
+
+  <script>
+    const observer = new IntersectionObserver(entries => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('visible');
+        }
+      });
+    }, {threshold: 0.2});
+
+    document.querySelectorAll('.fade-section').forEach(section => {
+      observer.observe(section);
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add standalone installation instructions page
- link call-to-action buttons on home page to new instructions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8bf5e3a4c83259fca87d0365cdcdd